### PR TITLE
feat: Add navigation link to access the '/tags' page

### DIFF
--- a/src/site.config.ts
+++ b/src/site.config.ts
@@ -41,6 +41,10 @@ export const menuLinks: Array<{ title: string; path: string }> = [
 		title: "Blog",
 		path: "/posts/",
 	},
+	{
+		title: "Tags",
+		path: "/tags/",
+	},
 ];
 
 // https://expressive-code.com/reference/configuration/


### PR DESCRIPTION
#### Description

Integrate a navigation link in the project to facilitate access to the '/tags' page. Users can now easily navigate to the tags section for a more organized and structured content experience.


